### PR TITLE
fix: YouTube HTTP links

### DIFF
--- a/docs/ext/video.py
+++ b/docs/ext/video.py
@@ -45,13 +45,13 @@ class IframeVideo(Directive):
 
 
 class Youtube(IframeVideo):
-    html = '<div class="embed-container"><iframe src="http://www.youtube.com/embed/%(video_id)s" \
+    html = '<div class="embed-container"><iframe src="https://www.youtube.com/embed/%(video_id)s" \
     width="%(width)u" height="%(height)u" frameborder="0" \
     webkitAllowFullScreen mozallowfullscreen allowfullscreen class="youtube"></iframe></div>'
 
 
 class Vimeo(IframeVideo):
-    html = '<div class="embed-container"><iframe src="http://player.vimeo.com/video/%(video_id)s" \
+    html = '<div class="embed-container"><iframe src="https://player.vimeo.com/video/%(video_id)s" \
     width="%(width)u" height="%(height)u" frameborder="0" \
     webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe></div>'
 


### PR DESCRIPTION
* YouTube links are currently generated with the HTTP schema. This
  causes mixed-content problems, as modern browsers refuse to load HTTP
  content on HTTPS websites.

* This commit updates the Sphinx extension that generates YouTube links
  so that they would be generated with HTTPS schema, which should
  mitigate the problem.

Signed-off-by: mr.Shu <mr@shu.io>