### PR TITLE
change line in Ch 7 so people don't unwittingly mess up a var

### DIFF
--- a/docs/filter/index.rst
+++ b/docs/filter/index.rst
@@ -38,13 +38,7 @@ From that result we can copy the full name of the proposition and place it betwe
 
     my_prop = 'PROPOSITION 064- MARIJUANA LEGALIZATION. INITIATIVE STATUTE.'
 
-Now, in the next cell we will form the filter expression expected by pandas.
-
-.. code-block:: python
-
-    committee_list.prop_name == my_prop
-
-That expression is then placed between two flat brackets following the variable we want to filter. Place the following code in the next open cell in your notebook.
+In the next cell we will ask pandas to narrow down our list of committees to just those that match the proposition we're interested in. We will create a filter expression that looks like this: :code:`committee_list.prop_name == my_prop`, and place it between two flat brackets following the variable we want to filter. Place the following code in the next open cell in your notebook.
 
 .. code-block:: python
 


### PR DESCRIPTION
This is a fix for a problem I encountered with a participant while coaching during the 3/28/2020 virtual class. Right now, the instructions for "Filtering a DataFrame" in Chapter 7 include a line of code showing a pandas filter expression.

```
Now, in the next cell we will form the filter expression expected by pandas.

`committee_list.prop_name == my_prop`
```

If you aren't paying close attention and you _run_ that line of code, you end up messing with your `committee_list` variable and then the next steps don't work. In the live version of the class, as people follow along, it works fine because Ben doesn't execute this line separately—and clearly it's printed here in the docs just to highlight what the filter expression is supposed to look like.

But for people catching up or following the scripted class, it's easy to overlook that the docs don't say to run this line. If they do, they can get stuck when their `my_committees` filtered variable later on has 0 entries.